### PR TITLE
Call destroy method on tomcat instances

### DIFF
--- a/common-tomcat-maven-plugin/src/main/java/org/apache/tomcat/maven/common/run/EmbeddedRegistry.java
+++ b/common-tomcat-maven-plugin/src/main/java/org/apache/tomcat/maven/common/run/EmbeddedRegistry.java
@@ -108,6 +108,7 @@ public final class EmbeddedRegistry
             {
                 Method method = embedded.getClass().getMethod( "stop", null );
                 method.invoke( embedded, null );
+                embedded.getClass().getMethod( "destroy", null ).invoke( embedded, null );
                 iterator.remove();
             }
             catch ( NoSuchMethodException e )
@@ -115,7 +116,7 @@ public final class EmbeddedRegistry
                 if ( firstException == null )
                 {
                     firstException = e;
-                    error( log, e, "no stop method in class " + embedded.getClass().getName() );
+                    error( log, e, "no stop/destroy method in class " + embedded.getClass().getName() );
                 }
                 else
                 {
@@ -127,7 +128,7 @@ public final class EmbeddedRegistry
                 if ( firstException == null )
                 {
                     firstException = e;
-                    error( log, e, "IllegalAccessException for stop method in class " + embedded.getClass().getName() );
+                    error( log, e, "IllegalAccessException for stop/destroy method in class " + embedded.getClass().getName() );
                 }
                 else
                 {
@@ -140,7 +141,7 @@ public final class EmbeddedRegistry
                 if ( firstException == null )
                 {
                     firstException = e;
-                    error( log, e, "IllegalAccessException for stop method in class " + embedded.getClass().getName() );
+                    error( log, e, "IllegalAccessException for stop/destroy method in class " + embedded.getClass().getName() );
                 }
                 else
                 {


### PR DESCRIPTION
Multi-module maven builds with several invocations of the tomcat7-maven-plugin are problematic because the ports from the first invokation remain bound. Calling destroy solves this.